### PR TITLE
Update gSP.cpp

### DIFF
--- a/src/gSP.cpp
+++ b/src/gSP.cpp
@@ -1175,7 +1175,7 @@ void gSPDMATriangles( u32 tris, u32 n )
 
         if ((gSP.geometryMode&G_CULL_BOTH) != mode)
         {
-            OGL_DrawTriangles();
+            
             gSP.geometryMode &= ~G_CULL_BOTH;
             gSP.geometryMode |= mode;
             gSP.changed |= CHANGED_GEOMETRYMODE;
@@ -1195,9 +1195,9 @@ void gSPDMATriangles( u32 tris, u32 n )
         triangles++;
     }
 
-#ifdef __TRIBUFFER_OPT
+
     OGL_DrawTriangles();
-#endif
+
 }
 
 void gSP1Quadrangle( s32 v0, s32 v1, s32 v2, s32 v3)


### PR DESCRIPTION
Fixes totally broken graphics in Diddy Kong Racing. Twinaphex from Libretro mentioned this in one of his changes. Tested on the raspberry pi and it worked. Diddy Kong Racing now runs at almost full speed with a 900MHz over clock. https://github.com/libretro/mupen64plus-libretro/commit/a4352f310def07c183311a4bcf996937d8746aab
