### PR TITLE
Update OpenGL.cpp

### DIFF
--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -197,6 +197,8 @@ void OGL_InitStates()
     //glDepthRangef(0.0f, (float)0x7FFF);  // what Yongzh used, broken on Adreno
     //glPolygonOffset(0.2f, 0.2f);
 /////
+	
+	glPolygonOffset(-3.0f, -3.0f);
     
 	DEBUG_PRINT("Video: OpenGL.cpp:%d glViewport(%d,%d,%d,%d)\n", __LINE__, config.framebuffer.xpos, config.framebuffer.ypos, config.framebuffer.width, config.framebuffer.height);
     glViewport(config.framebuffer.xpos, config.framebuffer.ypos, config.framebuffer.width, config.framebuffer.height);


### PR DESCRIPTION
Fixes shadows, wall and floor textures in Super Mario 64. Outside the Castle door frame renders correctly as well as the sun texture on the floor of the castle lobby. 