### PR TITLE
Fixes for gles2n64.conf saved location.

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <limits.h>
 
 #include "Config.h"
 #include "gles2N64.h"
@@ -266,9 +267,13 @@ void Config_LoadConfig()
     Config_SetDefault();
 
     // read configuration
-    const char *filename = ConfigGetSharedDataFilepath("gles2n64.conf");
+    //const char *filename = ConfigGetSharedDataFilepath("gles2n64.conf");
+    const char *userConfigPath = ConfigGetUserConfigPath();
+
+        char filename[PATH_MAX];
+	sprintf(filename, "%s/gles2n64.conf", userConfigPath);
 	
-	if (filename == NULL) filename = "gles2n64.conf";
+	//if (filename == NULL) filename = "gles2n64.conf";
 	
 	f = fopen(filename, "r");
 	if (!f)

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -266,12 +266,18 @@ void Config_LoadConfig()
     // default configuration
     Config_SetDefault();
 
-    // read configuration
-    //const char *filename = ConfigGetSharedDataFilepath("gles2n64.conf");
-    const char *userConfigPath = ConfigGetUserConfigPath();
-
-        char filename[PATH_MAX];
+    // read configuration from shared data path
+    const char *sharedDataFilename = ConfigGetSharedDataFilepath("gles2n64.conf");
+    char filename[PATH_MAX]; // store the path to the config file to open
+    if (sharedDataFilename == NULL)
+    {
+	// file does not exist in shared data path, therefore set the filename
+	// to the user's config path, e.g. $HOME/.config/mupen64plus
+    	const char *userConfigPath = ConfigGetUserConfigPath();
 	sprintf(filename, "%s/gles2n64.conf", userConfigPath);
+    } else {
+	strcpy(filename, sharedDataFilename);	
+    }
 	
 	//if (filename == NULL) filename = "gles2n64.conf";
 	

--- a/src/gles2N64.cpp
+++ b/src/gles2N64.cpp
@@ -26,6 +26,7 @@
 //#include "ae_bridge.h"
 
 ptr_ConfigGetSharedDataFilepath ConfigGetSharedDataFilepath = NULL;
+ptr_ConfigGetUserConfigPath ConfigGetUserConfigPath = NULL;
 ptr_VidExt_GL_SwapBuffers        CoreVideo_GL_SwapBuffers = NULL;
 ptr_VidExt_SetVideoMode          CoreVideo_SetVideoMode = NULL;
 ptr_VidExt_Init			 CoreVideo_Init = NULL;
@@ -43,6 +44,7 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle,
         void *Context, void (*DebugCallback)(void *, int, const char *))
 {
     ConfigGetSharedDataFilepath = (ptr_ConfigGetSharedDataFilepath)	dlsym(CoreLibHandle, "ConfigGetSharedDataFilepath");
+    ConfigGetUserConfigPath = (ptr_ConfigGetUserConfigPath)		dlsym(CoreLibHandle, "ConfigGetUserConfigPath");
 	CoreVideo_GL_SwapBuffers 	= (ptr_VidExt_GL_SwapBuffers) 	dlsym(CoreLibHandle, "VidExt_GL_SwapBuffers");
 	CoreVideo_SetVideoMode 		= (ptr_VidExt_SetVideoMode)	dlsym(CoreLibHandle, "VidExt_SetVideoMode");
 	CoreVideo_Init 				= (ptr_VidExt_Init)	dlsym(CoreLibHandle, "VidExt_Init");

--- a/src/gles2N64.h
+++ b/src/gles2N64.h
@@ -16,6 +16,7 @@
 #define PLUGIN_API_VERSION 0x020200
 
 extern ptr_ConfigGetSharedDataFilepath 	ConfigGetSharedDataFilepath;
+extern ptr_ConfigGetUserConfigPath	ConfigGetUserConfigPath;
 extern ptr_VidExt_GL_SwapBuffers       	CoreVideo_GL_SwapBuffers;
 extern ptr_VidExt_SetVideoMode		CoreVideo_SetVideoMode;
 extern ptr_VidExt_Init			CoreVideo_Init;


### PR DESCRIPTION
These changes mean that the gles2n64.conf file is now saved to the user's config directory (as defined by mupen64plus-core API, e.g. $HOME/.config/mupen64plus) rather than the current working directory, if a gles2n64.conf is not found in the shared data directory (as defined by mupen64plus-core API).

If a copy is found in the shared data directory, then this file will be used as before.