### PR TITLE
Add -DARM_ASM

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -127,8 +127,8 @@ LDFLAGS += $(SHARED)
 
 
 ifeq ("$(MACHINE)","armv6l")
-CFLAGS += -DARM -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
-CXXFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
+CFLAGS += -DARM -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux -DARM_ASM
+CXXFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux -DARM_ASM
 LDLIBS += -lm -L/opt/vc/lib -lGLESv2 -lEGL -lbcm_host
 endif
 


### PR DESCRIPTION
There are some #ifdef ARM_ASM locations:
https://github.com/ricrpi/mupen64plus-video-gles2n64/blob/52939edf257f6655be1ecc621478fa0507d9dd92/src/convert.h#L186
https://github.com/ricrpi/mupen64plus-video-gles2n64/blob/0cd825e01eb08477a075e09bb457c7a8bcc79709/src/OpenGL.cpp

It compiles and runs. I don't know if the ASM functions are really used. It feels fast/slow as ever.