### PR TITLE
Fix mario kart 64 split screen issue

### DIFF
--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -1461,7 +1461,7 @@ void OGL_ClearDepthBuffer()
     glClearColor( 0, 0, 0, 1 );
 	OPENGL_CHECK_ERRORS;
 
-    glClear( GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT );
+    glClear( GL_DEPTH_BUFFER_BIT );
 	OPENGL_CHECK_ERRORS;
 
     OGL_UpdateDepthUpdate();


### PR DESCRIPTION
The screen of the second player was black. Backport depth buffer change from mupen64plus-ae.