### PR TITLE
Keep aspect and add a function for OGL CoreVideo start

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -56,12 +56,16 @@ Option configOptions[] =
     {"", NULL, 0},
 
     {"#Window Settings:", NULL, 0},
-    {"window xpos", &config.window.xpos, 0},
-    {"window ypos", &config.window.ypos, 0},
+//    {"window xpos", &config.window.xpos, 0},
+//    {"window ypos", &config.window.ypos, 0},
     {"window width", &config.window.width, 400},
     {"window height", &config.window.height, 240},
-    {"window refwidth", &config.window.refwidth, 400},
-    {"window refheight", &config.window.refheight, 240},
+//    {"window refwidth", &config.window.refwidth, 400},
+//    {"window refheight", &config.window.refheight, 240},
+    {"multisampling", &config.multiSampling, 0},
+#ifdef VC
+    {"auto resolution", &config.useScreenResolution, 1},
+#endif
     {"", NULL, 0},
 
     {"#Framebuffer Settings:",NULL,0},
@@ -77,6 +81,7 @@ Option configOptions[] =
     {"video force", &config.video.force, 0},
     {"video width", &config.video.width, 320},
     {"video height", &config.video.height, 240},
+    {"video stretch", &config.stretchVideo, 0},
     {"", NULL, 0},
 
     {"#Render Settings:", NULL, 0},
@@ -96,10 +101,6 @@ Option configOptions[] =
     {"texture use IA", &config.texture.useIA, 0},
     {"texture fast CRC", &config.texture.fastCRC, 1},
     {"texture pow2", &config.texture.pow2, 1},
-    {"multisampling", &config.multiSampling, 0},
-#ifdef VC
-    {"auto resolution", &config.useScreenResolution, 1},
-#endif
     {"", NULL, 0},
 
     {"#Frame skip:", NULL, 0},

--- a/src/Config.h
+++ b/src/Config.h
@@ -69,7 +69,7 @@ struct Config
     int     hackAlpha;
 
 	int 	printFPS;
-    bool    stretchVideo;
+    int    	stretchVideo;
     bool    romPAL;    //is the rom PAL
     char    romName[21];
 };


### PR DESCRIPTION
gles2n64 runs 16:9 resolutions without any performance problem on a rpi2 but the
screen is stretched. I added the ini option strechVideo from pandora
mupen64plus. I also moved all CoreVideo init and CoreVideo_setVideo functions in
an own function (OGL_CoreVideo_Start) comparable to OGL_SDL_Start.