### PR TITLE
Build fix

### DIFF
--- a/src/gles2N64.cpp
+++ b/src/gles2N64.cpp
@@ -362,7 +362,7 @@ EXPORT void CALL ReadScreen2(void *dest, int *width, int *height, int front)
     OGL_ReadScreen(dest, width, height);
 }
 
-EXPORT void CALL SetRenderingCallback(void (*callback)())
+EXPORT void CALL SetRenderingCallback(void (*callback)(int))
 {
     renderCallback = callback;
 }

--- a/src/gles2N64.cpp
+++ b/src/gles2N64.cpp
@@ -38,21 +38,21 @@ static FrameSkipper frameSkipper;
 
 u32         last_good_ucode = (u32) -1;
 void        (*CheckInterrupts)( void );
-void        (*renderCallback)() = NULL;
+void        (*renderCallback)( int ) = NULL;
 
 extern "C" {
 
 EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle,
         void *Context, void (*DebugCallback)(void *, int, const char *))
 {
-    	ConfigGetSharedDataFilepath 	= (ptr_ConfigGetSharedDataFilepath)	dlsym(CoreLibHandle, "ConfigGetSharedDataFilepath");
-    	ConfigGetUserConfigPath 	= (ptr_ConfigGetUserConfigPath)		dlsym(CoreLibHandle, "ConfigGetUserConfigPath");
-	CoreVideo_GL_SwapBuffers 	= (ptr_VidExt_GL_SwapBuffers) 		dlsym(CoreLibHandle, "VidExt_GL_SwapBuffers");
-	CoreVideo_SetVideoMode 		= (ptr_VidExt_SetVideoMode)		dlsym(CoreLibHandle, "VidExt_SetVideoMode");
-	CoreVideo_GL_SetAttribute 	= (ptr_VidExt_GL_SetAttribute) 		dlsym(CoreLibHandle, "VidExt_GL_SetAttribute");
-    	CoreVideo_GL_GetAttribute 	= (ptr_VidExt_GL_GetAttribute) 		dlsym(CoreLibHandle, "VidExt_GL_GetAttribute");
-	CoreVideo_Init 			= (ptr_VidExt_Init)			dlsym(CoreLibHandle, "VidExt_Init");
-	CoreVideo_Quit 			= (ptr_VidExt_Quit)			dlsym(CoreLibHandle, "VidExt_Quit");
+    ConfigGetSharedDataFilepath = (ptr_ConfigGetSharedDataFilepath) dlsym(CoreLibHandle, "ConfigGetSharedDataFilepath");
+    ConfigGetUserConfigPath     = (ptr_ConfigGetUserConfigPath)     dlsym(CoreLibHandle, "ConfigGetUserConfigPath");
+    CoreVideo_GL_SwapBuffers    = (ptr_VidExt_GL_SwapBuffers)       dlsym(CoreLibHandle, "VidExt_GL_SwapBuffers");
+    CoreVideo_SetVideoMode      = (ptr_VidExt_SetVideoMode)         dlsym(CoreLibHandle, "VidExt_SetVideoMode");
+    CoreVideo_GL_SetAttribute   = (ptr_VidExt_GL_SetAttribute)      dlsym(CoreLibHandle, "VidExt_GL_SetAttribute");
+    CoreVideo_GL_GetAttribute   = (ptr_VidExt_GL_GetAttribute)      dlsym(CoreLibHandle, "VidExt_GL_GetAttribute");
+    CoreVideo_Init              = (ptr_VidExt_Init)                 dlsym(CoreLibHandle, "VidExt_Init");
+    CoreVideo_Quit              = (ptr_VidExt_Quit)                 dlsym(CoreLibHandle, "VidExt_Quit");
 
 #ifdef __VFP_OPT
     MathInitVFP();

--- a/src/gles2N64.h
+++ b/src/gles2N64.h
@@ -25,7 +25,7 @@ extern ptr_VidExt_Init			            CoreVideo_Init;
 extern ptr_VidExt_Quit                  CoreVideo_Quit;
 
 extern void (*CheckInterrupts)( void );
-extern void (*renderCallback)();
+extern void (*renderCallback)( int );
 
 
 #endif


### PR DESCRIPTION
This commit has a different function call for renderCallback: https://github.com/ricrpi/mupen64plus-video-gles2n64/commit/e76da377951e54f1f4c872fa9ef7b9e0428388b3#diff-d5ed3ef0924dbfeea50affc8bde95144R1736

gles2N64.cpp and gles2N64.h need to be modified to add the new parameter.