### PR TITLE
Pull fullscreen setting from MP64, via API. Previously always on.

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -133,7 +133,7 @@ endif
 OPTFLAGS ?= -O3 -flto
 WARNFLAGS ?= -Wall
 CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fno-strict-aliasing -fvisibility=hidden -I../../src -DSDL_VIDEO_OPENGL_ES2=1 -DSDL_VIDEO_OPENGL=0     
-CXXFLAGS += $(OPTFLAGS) -fvisibility-inlines-hidden -DSDL_VIDEO_OPENGL_ES2=1 -DSDL_VIDEO_OPENGL=0    
+CXXFLAGS += $(OPTFLAGS) -std=c++11 -fvisibility-inlines-hidden -DSDL_VIDEO_OPENGL_ES2=1 -DSDL_VIDEO_OPENGL=0    
 LDFLAGS += $(SHARED)
 
 ifeq ($(CRC_OPT), 1)

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -37,6 +37,9 @@
 
 Config config;
 
+m64p_handle g_configVideoGeneral = nullptr;
+m64p_handle g_configVideoGliden64 = nullptr;
+
 struct Option
 {
     const char* name;
@@ -321,6 +324,16 @@ void Config_LoadConfig()
 
 		fclose(f);
 	}
-	
+
+    // load mupen64plus config
+    if (ConfigOpenSection("Video-General", &g_configVideoGeneral) != M64ERR_SUCCESS) {
+        LOG(LOG_ERROR, "Unable to open Video-General configuration section");
+        g_configVideoGeneral = nullptr;
+    }
+
+    if (g_configVideoGeneral != nullptr)
+    {
+        config.video.fullscreen = ConfigGetParamBool(g_configVideoGeneral, "Fullscreen");
+    }
 }
 

--- a/src/Config.h
+++ b/src/Config.h
@@ -24,6 +24,7 @@ struct Config
     struct
     {
         int force, width, height;
+        int fullscreen;
     } video;
 
     struct

--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -409,7 +409,7 @@ bool OGL_CoreVideo_Start()
 	
 	/* Set the video mode */
     LOG(LOG_MINIMAL, "Setting video mode %dx%d...\n", current_w, current_h );
-    if (CoreVideo_SetVideoMode(current_w, current_h, 32, M64VIDEO_FULLSCREEN, flags) != M64ERR_SUCCESS)
+    if (CoreVideo_SetVideoMode(current_w, current_h, 32, config.video.fullscreen ? M64VIDEO_FULLSCREEN : M64VIDEO_WINDOWED, flags) != M64ERR_SUCCESS)
     {
 	printf("ERROR: Failed to set %i-bit video mode: %ix%i\n", 32, config.window.width, config.window.height);
 	return false;

--- a/src/gles2N64.cpp
+++ b/src/gles2N64.cpp
@@ -27,6 +27,11 @@
 
 ptr_ConfigGetSharedDataFilepath ConfigGetSharedDataFilepath = NULL;
 ptr_ConfigGetUserConfigPath 	ConfigGetUserConfigPath = NULL;
+ptr_ConfigOpenSection           ConfigOpenSection = NULL;
+ptr_ConfigGetParamInt           ConfigGetParamInt = NULL;
+ptr_ConfigGetParamFloat         ConfigGetParamFloat = NULL;
+ptr_ConfigGetParamBool          ConfigGetParamBool = NULL;
+ptr_ConfigGetParamString        ConfigGetParamString = NULL;
 ptr_VidExt_GL_SwapBuffers      	CoreVideo_GL_SwapBuffers = NULL;
 ptr_VidExt_SetVideoMode         CoreVideo_SetVideoMode = NULL;
 ptr_VidExt_GL_SetAttribute      CoreVideo_GL_SetAttribute = NULL;
@@ -47,7 +52,12 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle,
 {
     	ConfigGetSharedDataFilepath 	= (ptr_ConfigGetSharedDataFilepath)	dlsym(CoreLibHandle, "ConfigGetSharedDataFilepath");
     	ConfigGetUserConfigPath 	= (ptr_ConfigGetUserConfigPath)		dlsym(CoreLibHandle, "ConfigGetUserConfigPath");
-	CoreVideo_GL_SwapBuffers 	= (ptr_VidExt_GL_SwapBuffers) 		dlsym(CoreLibHandle, "VidExt_GL_SwapBuffers");
+    ConfigOpenSection     = (ptr_ConfigOpenSection)     dlsym(CoreLibHandle, "ConfigOpenSection");
+    ConfigGetParamInt     = (ptr_ConfigGetParamInt)     dlsym(CoreLibHandle, "ConfigGetParamInt");
+    ConfigGetParamFloat     = (ptr_ConfigGetParamFloat)     dlsym(CoreLibHandle, "ConfigGetParamFloat");
+    ConfigGetParamBool     = (ptr_ConfigGetParamBool)     dlsym(CoreLibHandle, "ConfigGetParamBool");
+    ConfigGetParamString     = (ptr_ConfigGetParamString)     dlsym(CoreLibHandle, "ConfigGetParamString");
+    CoreVideo_GL_SwapBuffers 	= (ptr_VidExt_GL_SwapBuffers) 		dlsym(CoreLibHandle, "VidExt_GL_SwapBuffers");
 	CoreVideo_SetVideoMode 		= (ptr_VidExt_SetVideoMode)		dlsym(CoreLibHandle, "VidExt_SetVideoMode");
 	CoreVideo_GL_SetAttribute 	= (ptr_VidExt_GL_SetAttribute) 		dlsym(CoreLibHandle, "VidExt_GL_SetAttribute");
     	CoreVideo_GL_GetAttribute 	= (ptr_VidExt_GL_GetAttribute) 		dlsym(CoreLibHandle, "VidExt_GL_GetAttribute");

--- a/src/gles2N64.h
+++ b/src/gles2N64.h
@@ -17,6 +17,11 @@
 
 extern ptr_ConfigGetSharedDataFilepath 	ConfigGetSharedDataFilepath;
 extern ptr_ConfigGetUserConfigPath	    ConfigGetUserConfigPath;
+extern ptr_ConfigOpenSection            ConfigOpenSection;
+extern ptr_ConfigGetParamInt            ConfigGetParamInt;
+extern ptr_ConfigGetParamFloat          ConfigGetParamFloat;
+extern ptr_ConfigGetParamBool           ConfigGetParamBool;
+extern ptr_ConfigGetParamString         ConfigGetParamString;
 extern ptr_VidExt_GL_SwapBuffers       	CoreVideo_GL_SwapBuffers;
 extern ptr_VidExt_SetVideoMode		      CoreVideo_SetVideoMode;
 extern ptr_VidExt_GL_SetAttribute       CoreVideo_GL_SetAttribute;


### PR DESCRIPTION
This means Retropie can run it in windowed mode at low resolution, and scale to display resolution using SDL/dispmanx scaling (better performance).